### PR TITLE
Improve lab discourse sync

### DIFF
--- a/app/models/discourse_service/lab.rb
+++ b/app/models/discourse_service/lab.rb
@@ -9,11 +9,20 @@ module DiscourseService
     end
 
     def name
-      @lab.name
+      "Discussion about #{@lab.name}"
     end
 
     def description
-      @lab.description
+      "<p>
+        #{@lab.description}
+      </p>
+      <p>
+        <a href='#{url}'>#{url}</a>
+      </p>"
+    end
+
+    def url
+      "#{Figaro.env.url}/#{@lab.slug}"
     end
 
     def category

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -86,7 +86,7 @@ class Lab < ActiveRecord::Base
   before_save :truncate_blurb
   before_save :get_time_zone unless Rails.env.test?
   after_save :save_roles
-  after_save :async_discourse_sync, if: Figaro.env.discourse_enabled
+  after_save :discourse_sync_if_needed, if: Figaro.env.discourse_enabled
 
   attr_accessor :geocomplete
 
@@ -222,16 +222,20 @@ class Lab < ActiveRecord::Base
   end
 
   def async_discourse_sync
-    if (changes.keys & ["name", "description"]).present?
-      DiscourseLabWorker.perform_async(self.id)
-    end
+    DiscourseLabWorker.perform_async(self.id)
   end
 
   def discourse_sync
     DiscourseService::Lab.new(self).sync
   end
 
-private
+  private
+
+  def discourse_sync_if_needed
+    if (changes.keys & ["name", "description"]).present?
+      async_discourse_sync
+    end
+  end
 
   def get_time_zone
     if latitude_changed? or longitude_changed?

--- a/db/migrate/20161128181536_change_discourse_errors_to_labs.rb
+++ b/db/migrate/20161128181536_change_discourse_errors_to_labs.rb
@@ -1,0 +1,5 @@
+class ChangeDiscourseErrorsToLabs < ActiveRecord::Migration
+  def change
+    change_column :labs, :discourse_errors, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161127073101) do
+ActiveRecord::Schema.define(version: 20161128181536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,7 +267,7 @@ ActiveRecord::Schema.define(version: 20161127073101) do
     t.boolean  "charter",                  default: false
     t.boolean  "public",                   default: false
     t.string   "discourse_id"
-    t.string   "discourse_errors"
+    t.text     "discourse_errors"
   end
 
   add_index "labs", ["creator_id"], name: "index_labs_on_creator_id", using: :btree

--- a/lib/tasks/discourse.rake
+++ b/lib/tasks/discourse.rake
@@ -1,15 +1,8 @@
 namespace :discourse do
   desc 'Sync all labs with discourse'
   task sync: :environment do
-
     Lab.find_each do |lab|
-      p lab.id
-      begin
-        DiscourseService::Lab.new(lab).sync
-      rescue => e
-        p e.message
-      end
+      lab.async_discourse_sync
     end
-
   end
 end


### PR DESCRIPTION
- Better title and raw to avoid discourse errors.
- Discourse errors as text instead of string
- rake task with async method