### PR TITLE
Improve backstage labs search

### DIFF
--- a/app/controllers/backstage/labs_controller.rb
+++ b/app/controllers/backstage/labs_controller.rb
@@ -8,7 +8,6 @@ class Backstage::LabsController < Backstage::BackstageController
       @q = Lab.includes(:creator).where("referee_id IN (?)",  current_user.admin_labs.map{ |u| u.resource_id }).search(params[:q])
     end
 
-    @q.workflow_state_eq = 'unverified' unless params[:q]
     @q.sorts = 'id desc' if @q.sorts.empty?
     @labs = @q.result.page(params[:page]).per(params[:per])
     #(distinct: true)

--- a/app/views/backstage/labs/index.html.haml
+++ b/app/views/backstage/labs/index.html.haml
@@ -9,13 +9,15 @@
         .row
           .columns.large-3
             = f.input :discourse_id_not_null, as: :boolean, label: "With discourse ID"
-          .columns.large-9
-            = f.input :discourse_errors_present, as: :boolean, label: "With discourse sync errors"
+          .columns.large-3
+            = f.input :discourse_id_null, as: :boolean, label: "Without discourse ID"
+          .columns.large-6
+            = f.input :discourse_errors_not_null, as: :boolean, label: "With discourse sync errors"
         .row
           .columns.large-4
-            = f.input :country_code_eq, as: 'country', label: 'Country', iso_codes: true
+            = f.input :country_code_eq, as: 'country', label: 'Country', iso_codes: true, prompt: 'ALL'
           .columns.large-4
-            = f.input :workflow_state_eq, collection: Lab.workflow_spec.state_names, label: "State"
+            = f.input :workflow_state_eq, collection: Lab.workflow_spec.state_names, label: "State", prompt: 'ALL'
           .columns.large-3
             = f.submit "Filter", class: 'button expand'
 


### PR DESCRIPTION
- Allow filter by discourse_id null or not null
- Discourse errors check null instead of blank
- Workflow state and country code include all options