### PR TITLE
Remove favicon method because it is not reliable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,21 +43,6 @@ module ApplicationHelper
     controller.class.parent == Backstage
   end
 
-  def favicon url
-    begin
-      domain = URI.parse(url).host
-      ['facebook.com','twitter.com','youtube.com','picasaweb.google.com','flickr.com','pinterest.com','github.com','vimeo.com', 'fablabbcn.org'].each do |s|
-        if domain.match(/(www\.)?#{s}/)
-          return image_tag hocho("http://#{domain}/favicon.ico", "o=t&q=80&d=16x16"), width: 16, height: 16
-        end
-      end
-    rescue
-      fa_icon "link"
-    end
-
-    fa_icon "link"
-  end
-
   def player url
     domain = URI.parse(url).host
     if domain.match(/(www\.)?#{'youtube.com'}/)

--- a/app/views/labs/_links.html.haml
+++ b/app/views/labs/_links.html.haml
@@ -5,5 +5,5 @@
       - cache ["v1", link] do
         %li.lab-link
           = link_to link.url do
-            = favicon link.url
+            = fa_icon 'link'
             %span.url{itemprop: "sameAs"}= link.url

--- a/app/views/machines/show.html.haml
+++ b/app/views/machines/show.html.haml
@@ -39,7 +39,7 @@
           - @machine.links.each do |link|
             %li.machine-link
               = link_to link.url do
-                = favicon link.url
+                = fa_icon 'link'
                 %span.url{itemprop: "sameAs"}= link.description
 
       .heading Machine Revisions

--- a/app/views/projects/_steps.html.haml
+++ b/app/views/projects/_steps.html.haml
@@ -18,5 +18,5 @@
             .flex-video
               = raw container
           - else
-            = favicon link.url
+            = fa_icon 'link'
             %span.url{itemprop: "sameAs"}= link.url


### PR DESCRIPTION
It is not reliable because depend of a third party file that could not
exists in the future.