### PR TITLE
Discourse embed test

### DIFF
--- a/app/controllers/discourse_controller.rb
+++ b/app/controllers/discourse_controller.rb
@@ -1,5 +1,6 @@
 class DiscourseController < ApplicationController
   before_filter :require_login
+
   def sso
     secret = Figaro.env.discourse_sso_secret
     sso = SingleSignOn.parse(request.query_string, secret)
@@ -15,5 +16,8 @@ class DiscourseController < ApplicationController
     Rails.logger.error(e.backtrace)
     flash[:error] = 'SSO error'
     redirect_to root_path
+  end
+
+  def embed
   end
 end

--- a/app/views/discourse/embed.html.haml
+++ b/app/views/discourse/embed.html.haml
@@ -1,0 +1,1 @@
+%iframe{src: Figaro.env.discourse_endpoint, width: '100%', scrolling: 'yes', height: 1000, style: 'border: none'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Fablabs::Application.routes.draw do
   get "discourse/sso"
+  get "discourse/embed"
   resources :pages, only: [:show]
   use_doorkeeper
   require 'sidekiq/web'


### PR DESCRIPTION
Just for testings purposes.

After deploy visit: https://www.fablabs.io/discourse/embed 

It requires apply a patch to discourse: https://gist.github.com/ceritium/81ce237f3e3a18476494dcc3a4f29cc0

Part of: https://github.com/fablabbcn/fablabs/issues/240

Or install the plugin https://github.com/B-Translator/discourse-allow-same-origin